### PR TITLE
Remove `start` and `end` date from `work schema`

### DIFF
--- a/.changeset/rotten-hotels-beam.md
+++ b/.changeset/rotten-hotels-beam.md
@@ -1,0 +1,7 @@
+---
+"@suddenlygiovanni/resume": minor
+---
+
+Remove start and end date from work schema.
+- the same information can now be derived from the Role schema.
+- the changes in schema have also been reflected in the `resume.yml`

--- a/resume.yml
+++ b/resume.yml
@@ -31,8 +31,6 @@ work:
     location: Berlin, Germany
     description: EdTech
     url: https://bettermarks.com
-    startDate: '2021-04-01'
-    endDate: '2021-10-31'
     summary: |
       Bettermarks is a software company that has developed an adaptive learning platform for highly interactive math books to be used in schools, enabling students to learn from their mistakes through AHA moments.
     roles:
@@ -68,8 +66,6 @@ work:
     location: Berlin, Germany
     description: B2B SAAS
     url: https://www.tooltime.de/
-    startDate: '2019-09-01'
-    endDate: '2020-02-29'
     summary: |
       ToolTime's mission is to help craftsmen tackle all their administrative tasks digitally with ease.
     roles:
@@ -103,8 +99,6 @@ work:
     location: Hamburg, Germany
     description: Digital Product Design Studio
     url: https://appico.com/
-    startDate: '2019-01-01'
-    endDate: '2019-02-28'
     roles:
       - title: React Native Developer
         startDate: "2019-01-01"
@@ -158,8 +152,6 @@ work:
   - name: MadeByEnka
     location: Rijeka, Croatia
     description: Handmade Fashion e-commerce
-    startDate: '2016-10-01'
-    endDate: '2017-06-30'
     summary: Co-founded and managed a Lifestyle brand with my wife.
     roles:
       - title: Front-end Web Developer
@@ -176,8 +168,6 @@ work:
   - name: Ravalico Real Estate s.a.s
     location: Trieste, Italy
     description: Real Estate Agency
-    startDate: '2015-10-01'
-    endDate: '2016-10-30'
     summary: Helped the company in its modernization process by pivoting its business model from brick and mortar to an online-first presence.
     highlights:
       - Architected, designed, and code multiple iterations of an in-house real estate CMS web app.

--- a/schema.json
+++ b/schema.json
@@ -578,9 +578,6 @@
 						"title": "description",
 						"type": "string"
 					},
-					"endDate": {
-						"$ref": "#/$defs/iso8601"
-					},
 					"highlights": {
 						"additionalItems": false,
 						"description": "Specify multiple accomplishments",
@@ -752,9 +749,6 @@
 						"minItems": 1,
 						"type": "array"
 					},
-					"startDate": {
-						"$ref": "#/$defs/iso8601"
-					},
 					"summary": {
 						"description": "A brief introduction of what the company does; a tagline, a mission statement, an elevator pitch; something that gives a sense of the company in a few words",
 						"examples": [
@@ -781,7 +775,7 @@
 						"description": "e.g. http://facebook.example.com"
 					}
 				},
-				"required": ["description", "name", "startDate", "roles"],
+				"required": ["description", "name", "roles"],
 				"type": "object"
 			},
 			"type": "array"

--- a/src/resume-schema/resume-schema.snapshot.json
+++ b/src/resume-schema/resume-schema.snapshot.json
@@ -508,16 +508,10 @@
         "required": [
           "description",
           "name",
-          "startDate",
           "roles"
         ],
         "properties": {
           "description": {
-            "type": "string",
-            "description": "a string",
-            "title": "string"
-          },
-          "endDate": {
             "type": "string",
             "description": "a string",
             "title": "string"
@@ -528,11 +522,6 @@
             "title": "string"
           },
           "name": {
-            "type": "string",
-            "description": "a string",
-            "title": "string"
-          },
-          "startDate": {
             "type": "string",
             "description": "a string",
             "title": "string"

--- a/src/resume-schema/work/work-schema.snapshot.json
+++ b/src/resume-schema/work/work-schema.snapshot.json
@@ -4,16 +4,10 @@
 	"required": [
 		"description",
 		"name",
-		"startDate",
 		"roles"
 	],
 	"properties": {
 		"description": {
-			"type": "string",
-			"description": "a string",
-			"title": "string"
-		},
-		"endDate": {
 			"type": "string",
 			"description": "a string",
 			"title": "string"
@@ -24,11 +18,6 @@
 			"title": "string"
 		},
 		"name": {
-			"type": "string",
-			"description": "a string",
-			"title": "string"
-		},
-		"startDate": {
 			"type": "string",
 			"description": "a string",
 			"title": "string"

--- a/src/resume-schema/work/work.spec.ts
+++ b/src/resume-schema/work/work.spec.ts
@@ -8,7 +8,6 @@ import { Work } from './work.js'
 describe('Work', () => {
 	const workInput = {
 		description: 'Social Media Company',
-		endDate: '1989-02-01',
 		location: 'Menlo Park, CA',
 		name: 'Facebook',
 		roles: [
@@ -19,7 +18,6 @@ describe('Work', () => {
 				responsibilities: ['Designed and built web applications', 'Managed a team of 10 engineers'],
 			},
 		],
-		startDate: '1988-02-01',
 		summary: 'My day-to-day activities involved designing and building web applications...',
 		url: 'https://facebook.example.com',
 		contact: {
@@ -33,7 +31,6 @@ describe('Work', () => {
 		name: workInput.name,
 		roles: workInput.roles,
 		description: workInput.description,
-		startDate: workInput.startDate,
 	}
 
 	describe('decode', () => {
@@ -106,37 +103,11 @@ describe('Work', () => {
 			).not.toThrow()
 		})
 
-		describe('dates', () => {
-			test('startDate', () => {
-				expect(() => parse({ ...required, startDate: '' })).toThrow()
-				expect(() => parse({ ...required, startDate: ' ' })).toThrow()
-				expect(() => parse({ ...required, startDate: workInput.startDate })).not.toThrow()
-				expect(parse({ ...required, startDate: workInput.startDate }).startDate).toBe('1988-02-01')
-			})
-
-			test('endDate', () => {
-				expect(() => parse({ ...required, endDate: '' })).toThrow()
-				expect(() => parse({ ...required, endDate: ' ' })).toThrow()
-				expect(() => parse({ ...required, endDate: workInput.endDate })).not.toThrow()
-				expect(parse({ ...required, endDate: workInput.endDate }).endDate).toBe('1989-02-01')
-			})
-
-			test.todo('start date before end date', () => {
-				const input: S.Schema.Encoded<typeof Work> = {
-					...required,
-					endDate: '1968-02-01',
-					startDate: '1969-05-01',
-				}
-				expect(() => parse(input)).toThrow()
-			})
-		})
-
 		test('techStack', () => {
 			const workInput: S.Schema.Encoded<typeof Work> = {
 				name: required.name,
 				roles: required.roles,
 				description: required.description,
-				startDate: required.startDate,
 				techStack: ['TypeScript', 'Aws', 'SQLite'],
 			}
 			expect(() => parse(required)).not.toThrow()

--- a/src/resume-schema/work/work.ts
+++ b/src/resume-schema/work/work.ts
@@ -26,15 +26,6 @@ export class Work extends S.Class<Work>('Work')({
 		examples: ['Social Media Company', 'Educational Software Company'],
 	}),
 
-	endDate: S.optional(
-		StringDate.annotations({
-			title: 'endDate',
-			description: 'The date when you stopped working at the company',
-			examples: ['2012-01-01'],
-		}),
-		{ exact: true },
-	),
-
 	location: S.optional(
 		TrimmedNonEmpty.annotations({
 			title: 'location',
@@ -53,12 +44,6 @@ export class Work extends S.Class<Work>('Work')({
 	roles: S.NonEmptyArray(Role).annotations({
 		title: 'roles',
 		description: 'The roles you had at the company, in reverse chronological order',
-	}),
-
-	startDate: StringDate.annotations({
-		title: 'startDate',
-		description: 'The date when you started working at the company',
-		examples: ['2011-01-01'],
 	}),
 
 	summary: S.optional(


### PR DESCRIPTION
Remove the start and end date from the work schema.

- the same information can now be derived from the Role schema.
- the changes in schema have also been reflected in the `resume.yml`
