### PR TITLE
Remove path aliases from build artefacts

### DIFF
--- a/.changeset/famous-balloons-warn.md
+++ b/.changeset/famous-balloons-warn.md
@@ -1,0 +1,13 @@
+---
+"@suddenlygiovanni/resume": patch
+---
+
+Configuration Update:
+The baseUrl and paths settings in the TypeScript configuration file (tsconfig.json) have been
+deactivated (commented out) to default TypeScript's module resolution strategy back to its default,
+and to avoid any conflicts with other module resolution settings in the project.
+
+Import Refactoring:
+Absolute imports in the src directory have been replaced with relative imports in an effort to
+prevent import issues and enhance code modularity.
+Additionally, this refactoring aims to improve the overall consistency of the project.

--- a/src/schema-primitive/email/email.ts
+++ b/src/schema-primitive/email/email.ts
@@ -1,5 +1,5 @@
-import { omit } from '../trimmed-non-empty/trimmed-non-empty.js'
 import * as S from '@effect/schema/Schema'
+import { omit } from '../trimmed-non-empty/trimmed-non-empty.js'
 
 const email =
 	<A extends string>(annotations?: S.Annotations.Filter<A>) =>

--- a/src/schema-primitive/iso8601-date-string/iso8601-date-string.spec.ts
+++ b/src/schema-primitive/iso8601-date-string/iso8601-date-string.spec.ts
@@ -4,8 +4,7 @@ import * as Either from 'effect/Either'
 import { pipe } from 'effect/Function'
 import { describe, expect, test } from 'vitest'
 
-import { expectEitherRight } from '@/test/test-utils.js'
-
+import { expectEitherRight } from '../../test/test-utils.js'
 import { ISO8601DateString } from './iso8601-date-string.js'
 
 // decode: transform data from an input type `Encoded` to an output type `Type`

--- a/src/schema-primitive/non-empty-string/non-empty-string.spec.ts
+++ b/src/schema-primitive/non-empty-string/non-empty-string.spec.ts
@@ -3,8 +3,8 @@ import * as S from '@effect/schema/Schema'
 import { identity } from 'effect/Function'
 import { describe, expect, test } from 'vitest'
 
-import { nonEmptyString } from '@/schema-primitive/non-empty-string/non-empty-string.js'
-import { expectEitherRight } from '@/test/test-utils.js'
+import { expectEitherRight } from '../../test/test-utils.js'
+import { nonEmptyString } from './non-empty-string.js'
 
 describe('nonEmptyString', () => {
 	const NonEmptyString = nonEmptyString()

--- a/src/schema-primitive/trimmed-non-empty/trimmed-non-empty.spec.ts
+++ b/src/schema-primitive/trimmed-non-empty/trimmed-non-empty.spec.ts
@@ -3,8 +3,8 @@ import * as jsonSchema from '@effect/schema/JSONSchema'
 import * as S from '@effect/schema/Schema'
 import { describe, expect, test } from 'vitest'
 
-import { expectEitherRight, expectEitherLeft } from '@/test/test-utils.js'
-import { trimmedNonEmpty, TrimmedNonEmpty } from './trimmed-non-empty.js'
+import { expectEitherLeft, expectEitherRight } from '../../test/test-utils.js'
+import { TrimmedNonEmpty, trimmedNonEmpty } from './trimmed-non-empty.js'
 
 describe('trimmedNonEmpty', () => {
 	describe('Regex Pattern', () => {

--- a/src/schema-resume/award/award.ts
+++ b/src/schema-resume/award/award.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { StringDate, TrimmedNonEmpty } from '@/schema-primitive/index.js'
+import { StringDate, TrimmedNonEmpty } from '../../schema-primitive/index.js'
 
 export class Award extends S.Class<Award>('Award')({
 	awarder: S.optional(

--- a/src/schema-resume/basics/basics.ts
+++ b/src/schema-resume/basics/basics.ts
@@ -1,7 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { Email, Phone, UrlString, TrimmedNonEmpty } from '@/schema-primitive/index.js'
-
+import { Email, Phone, TrimmedNonEmpty, UrlString } from '../../schema-primitive/index.js'
 import { Location } from '../location/location.js'
 import { Profile } from '../profile/profile.js'
 

--- a/src/schema-resume/certificates/certificates.ts
+++ b/src/schema-resume/certificates/certificates.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { UrlString, TrimmedNonEmpty, StringDate } from '@/schema-primitive/index.js'
+import { StringDate, TrimmedNonEmpty, UrlString } from '../../schema-primitive/index.js'
 
 export class Certificate extends S.Class<Certificate>('Certificate')({
 	name: S.optional(

--- a/src/schema-resume/education/education.ts
+++ b/src/schema-resume/education/education.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { UrlString, TrimmedNonEmpty, StringDate } from '@/schema-primitive/index.js'
+import { StringDate, TrimmedNonEmpty, UrlString } from '../../schema-primitive/index.js'
 
 export class Education extends S.Class<Education>('Education')({
 	area: TrimmedNonEmpty.annotations({

--- a/src/schema-resume/interest/interest.ts
+++ b/src/schema-resume/interest/interest.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { TrimmedNonEmpty } from '@/schema-primitive/index.js'
+import { TrimmedNonEmpty } from '../../schema-primitive/index.js'
 
 export class Interest extends S.Class<Interest>('Interest')({
 	keywords: S.optional(

--- a/src/schema-resume/language/language.ts
+++ b/src/schema-resume/language/language.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { TrimmedNonEmpty } from '@/schema-primitive/index.js'
+import { TrimmedNonEmpty } from '../../schema-primitive/index.js'
 
 export class Language extends S.Class<Language>('Language')({
 	fluency: S.optional(

--- a/src/schema-resume/location/location.ts
+++ b/src/schema-resume/location/location.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { omit, TrimmedNonEmpty } from '@/schema-primitive/index.js'
+import { TrimmedNonEmpty, omit } from '../../schema-primitive/index.js'
 
 const countryCode =
 	<A extends string>(annotations?: S.Annotations.Filter<A>) =>

--- a/src/schema-resume/profile/profile.ts
+++ b/src/schema-resume/profile/profile.ts
@@ -1,6 +1,5 @@
 import * as S from '@effect/schema/Schema'
-
-import { UrlString, TrimmedNonEmpty } from '@/schema-primitive/index.js'
+import { TrimmedNonEmpty, UrlString } from '../../schema-primitive/index.js'
 
 export class Profile extends S.Class<Profile>('Profile')({
 	network: TrimmedNonEmpty.annotations({

--- a/src/schema-resume/project/project.ts
+++ b/src/schema-resume/project/project.ts
@@ -1,6 +1,5 @@
 import * as S from '@effect/schema/Schema'
-
-import { UrlString, TrimmedNonEmpty, StringDate } from '@/schema-primitive/index.js'
+import { StringDate, TrimmedNonEmpty, UrlString } from '../../schema-primitive/index.js'
 
 export class Project extends S.Class<Project>('Project')({
 	description: S.optional(

--- a/src/schema-resume/publication/publication.ts
+++ b/src/schema-resume/publication/publication.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { UrlString, TrimmedNonEmpty, StringDate } from '@/schema-primitive/index.js'
+import { StringDate, TrimmedNonEmpty, UrlString } from '../../schema-primitive/index.js'
 
 export class Publication extends S.Class<Publication>('Publication')({
 	name: S.optional(

--- a/src/schema-resume/reference/reference.ts
+++ b/src/schema-resume/reference/reference.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { TrimmedNonEmpty } from '@/schema-primitive/index.js'
+import { TrimmedNonEmpty } from '../../schema-primitive/index.js'
 
 export class Reference extends S.Class<Reference>('Reference')({
 	name: TrimmedNonEmpty.annotations({

--- a/src/schema-resume/skill/skill.ts
+++ b/src/schema-resume/skill/skill.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { TrimmedNonEmpty } from '@/schema-primitive/index.js'
+import { TrimmedNonEmpty } from '../../schema-primitive/index.js'
 
 export class Skill extends S.Class<Skill>('Skill')({
 	keywords: S.Array(

--- a/src/schema-resume/volunteer/volunteer.ts
+++ b/src/schema-resume/volunteer/volunteer.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { StringDate, UrlString, TrimmedNonEmpty } from '@/schema-primitive/index.js'
+import { StringDate, TrimmedNonEmpty, UrlString } from '../../schema-primitive/index.js'
 
 export class Volunteer extends S.Class<Volunteer>('Volunteer')({
 	endDate: S.optional(StringDate, { exact: true }),

--- a/src/schema-resume/work/role.ts
+++ b/src/schema-resume/work/role.ts
@@ -1,6 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { StringDate, TrimmedNonEmpty } from '@/schema-primitive/index.js'
+import { StringDate, TrimmedNonEmpty } from '../../schema-primitive/index.js'
 
 export class Role extends S.Class<Role>('Role')({
 	title: TrimmedNonEmpty.annotations({

--- a/src/schema-resume/work/work.ts
+++ b/src/schema-resume/work/work.ts
@@ -1,7 +1,6 @@
 import * as S from '@effect/schema/Schema'
 
-import { Email, Phone, UrlString, TrimmedNonEmpty } from '@/schema-primitive/index.js'
-
+import { Email, Phone, TrimmedNonEmpty, UrlString } from '../../schema-primitive/index.js'
 import { Role } from './role.js'
 
 export class Work extends S.Class<Work>('Work')({

--- a/src/test/integration-test.spec.ts
+++ b/src/test/integration-test.spec.ts
@@ -3,7 +3,7 @@ import * as S from '@effect/schema/Schema'
 import * as yaml from '@std/yaml'
 import { describe, expect, it } from 'vitest'
 
-import { Resume } from '@/schema-resume/resume.js'
+import { Resume } from '../schema-resume/resume.js'
 
 describe('integration test', () => {
 	it('resume.yml should fulfill Resume schema constraints', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,8 +29,8 @@
     // "module": "commonjs",                             /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-		"baseUrl": "./",                                     /* Specify the base directory to resolve non-relative module names. */
-    "paths": { "@/*": ["src/*"] },                       /* Specify a set of entries that re-map imports to additional lookup locations. */
+		// "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+		// "paths": { "@/*": ["src/*"] },                    /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     "types": [


### PR DESCRIPTION
Configuration Update:
The baseUrl and paths settings in the TypeScript configuration file (tsconfig.json) have been
deactivated (commented out) to default TypeScript's module resolution strategy back to its default,
and to avoid any conflicts with other module resolution settings in the project.

Import Refactoring:
Absolute imports in the src directory have been replaced with relative imports in an effort to
prevent import issues and enhance code modularity.
Additionally, this refactoring aims to improve the overall consistency of the project.