### PR TITLE
feat(config): refactor project into monorepo structure

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,6 @@
 	"$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
 	"changelog": "@changesets/cli/changelog",
 	"commit": false,
-	"fixed": [["@suddenlygiovanni/*"]],
 	"linked": [],
 	"access": "restricted",
 	"baseBranch": "main",

--- a/.changeset/nervous-worms-perform.md
+++ b/.changeset/nervous-worms-perform.md
@@ -1,0 +1,7 @@
+---
+"@suddenlygiovanni/schema-resume": major
+---
+
+Refactored project into a monorepo, decoupling resume data from the schema and improving project
+structure. This involved updating build processes, linting, formatting, and configuration files. The
+resume is now a separate package and build process now publishes only the schema package.


### PR DESCRIPTION
Refactored the project into a monorepo, separating resume data from the schema. Updated build processes, configuration, and project structure. Resume is now a distinct package, and schema package is independently published.