### PR TITLE
Renovate/deps

### DIFF
--- a/.changeset/neat-drinks-check.md
+++ b/.changeset/neat-drinks-check.md
@@ -1,0 +1,11 @@
+---
+"@suddenlygiovanni/schema-resume": patch
+---
+
+- chore: update dependencies to:
+	- `@vitest/coverage-v8`: 3.0.0-beta.3 → 3.0.0-beta.4
+	- `@vitest/ui`: 3.0.0-beta.3 → 3.0.0-beta.4
+	- `effect`: 3.12.0 → 3.12.1
+	- `vite-node`: 3.0.0-beta.3 → 3.0.0-beta.4
+	- `vitest`: 3.0.0-beta.3 → 3.0.0-beta.4
+	- `typescript`: 5.7.2 → 5.7.3

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ dist
 /resume.iml
 /.direnv/
 /packages/schema-resume/lib/
+**/.vite/

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"typescript": "catalog:",
 		"vitest": "catalog:"
 	},
-	"packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321",
+	"packageManager": "pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a",
 	"engines": {
 		"node": ">=23",
 		"pnpm": ">=9.15"

--- a/packages/schema-resume/package.json
+++ b/packages/schema-resume/package.json
@@ -23,7 +23,7 @@
 	"license": "MIT",
 	"name": "@suddenlygiovanni/schema-resume",
 	"peerDependencies": {
-		"effect": "~3.12.0"
+		"effect": "~3.12.1"
 	},
 	"publishConfig": {
 		"registry": "https://npm.pkg.github.com",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,11 +28,11 @@ catalogs:
       specifier: 22.10.5
       version: 22.10.5
     '@vitest/coverage-v8':
-      specifier: 3.0.0-beta.3
-      version: 3.0.0-beta.3
+      specifier: 3.0.0-beta.4
+      version: 3.0.0-beta.4
     '@vitest/ui':
-      specifier: 3.0.0-beta.3
-      version: 3.0.0-beta.3
+      specifier: 3.0.0-beta.4
+      version: 3.0.0-beta.4
     effect:
       specifier: 3.12.1
       version: 3.12.1
@@ -40,8 +40,8 @@ catalogs:
       specifier: 5.7.3
       version: 5.7.3
     vitest:
-      specifier: 3.0.0-beta.3
-      version: 3.0.0-beta.3
+      specifier: 3.0.0-beta.4
+      version: 3.0.0-beta.4
 
 importers:
 
@@ -64,16 +64,16 @@ importers:
         version: 22.10.5
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 3.0.0-beta.3(vitest@3.0.0-beta.3)
+        version: 3.0.0-beta.4(vitest@3.0.0-beta.4)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 3.0.0-beta.3(vitest@3.0.0-beta.3)
+        version: 3.0.0-beta.4(vitest@3.0.0-beta.4)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
       vitest:
         specifier: 'catalog:'
-        version: 3.0.0-beta.3(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.3)
+        version: 3.0.0-beta.4(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.4)
 
   packages/resume:
     devDependencies:
@@ -91,7 +91,7 @@ importers:
         version: 3.12.1
       vitest:
         specifier: 'catalog:'
-        version: 3.0.0-beta.3(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.3)
+        version: 3.0.0-beta.4(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.4)
 
   packages/schema-resume:
     devDependencies:
@@ -106,7 +106,7 @@ importers:
         version: 3.12.1
       vitest:
         specifier: 'catalog:'
-        version: 3.0.0-beta.3(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.3)
+        version: 3.0.0-beta.4(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.4)
 
 packages:
 
@@ -135,8 +135,9 @@ packages:
     resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
-  '@bcoe/v8-coverage@0.2.3':
-    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+  '@bcoe/v8-coverage@1.0.1':
+    resolution: {integrity: sha512-W+a0/JpU28AqH4IKtwUPcEUnUyXMDLALcn5/JLczGGT9fHE2sIby/xP/oQnx3nxkForzgzPy201RAKcB4xPAFQ==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@1.9.4':
     resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
@@ -563,20 +564,20 @@ packages:
   '@types/node@22.10.5':
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
 
-  '@vitest/coverage-v8@3.0.0-beta.3':
-    resolution: {integrity: sha512-jtlEKBuku+gOxhwAAswmNU6V+uPAMKg2zp6sNt+jUbD3+cgdjmYsiFrxHwGg8hiuYFrZwewid5AET8bjCdca/w==}
+  '@vitest/coverage-v8@3.0.0-beta.4':
+    resolution: {integrity: sha512-vvg9etiUUBYNB6TX29za69xBkcil+tfUQh8M0h7WQVlJXM6va7AJqHCVp+UpcXLA7vqBJY1b5PTODuNFHjkCHQ==}
     peerDependencies:
-      '@vitest/browser': 3.0.0-beta.3
-      vitest: 3.0.0-beta.3
+      '@vitest/browser': 3.0.0-beta.4
+      vitest: 3.0.0-beta.4
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.0.0-beta.3':
-    resolution: {integrity: sha512-KPxQ9FkPT5SBIBonCmDZe2XY6RKmSTl/ghzjAHip08GZXaZs/tp/iyE5ypFSTCoP3kdTc9TPdXpibHjdDmLMvw==}
+  '@vitest/expect@3.0.0-beta.4':
+    resolution: {integrity: sha512-wBBhMoM1z5M8exSDA8IkCjy4a83T10qwLmFHYjGiLQ3rV8OlexjGNOm28rRokcG+oYgR2+zcH3GU6sl/IKf/3g==}
 
-  '@vitest/mocker@3.0.0-beta.3':
-    resolution: {integrity: sha512-biBESFwOzhB+3DZq5pnkGkiA0Xt7hvSU1m2jsY8pK/h6wS8kRYcFvN1o/38wkGZ6Ss+wjvTixqfCwrlqFz9Fnw==}
+  '@vitest/mocker@3.0.0-beta.4':
+    resolution: {integrity: sha512-VjQu8F5N57SvSvD7xOfl6r2R78/qOtj7ySHaG9OQLTc6O6jb+AYBGsDE+N6spFf25BuIwZIcUFlk+wvXMNEHEQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -586,25 +587,25 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.0.0-beta.3':
-    resolution: {integrity: sha512-d3+IaliPJLndUB/eQ4XP4OEHWhMDUJGhGc8XyLfi803Ad62nkTLC1bwFz80bNghEfKi+sz/oSkvQmW/3lQeCdA==}
+  '@vitest/pretty-format@3.0.0-beta.4':
+    resolution: {integrity: sha512-uwgWpsHabr96/YnrzNY+NQUgnza8rFq6wYW/yR1FrgRfQtVTS1loOPQSydRkUDk307bUzMVyyh7aVRwtLgHkDg==}
 
-  '@vitest/runner@3.0.0-beta.3':
-    resolution: {integrity: sha512-9ibO4DPJAyyxQfGDOCpMY36M4XFOX4G4VNmDr25dzrEmJ8sMt8/8E6kdb5lV/m0holHJFgvpGZr8zhXkWQ4+cg==}
+  '@vitest/runner@3.0.0-beta.4':
+    resolution: {integrity: sha512-+tTASu585TT23AeO+bOBSQ/2nin66nPqOznDCB1HQJ8+Mb3gtOw9faJwQEZ9uPRNhi/mLNau4k9Zig1p/AnntQ==}
 
-  '@vitest/snapshot@3.0.0-beta.3':
-    resolution: {integrity: sha512-jsWdfQWRcbI1WIpxi2X6jUAAjJY898iK4P/ZzxgkBPFrPK894HXkCm3xcF/sZHF9nHNa61ZIgfgddnH0blkiFQ==}
+  '@vitest/snapshot@3.0.0-beta.4':
+    resolution: {integrity: sha512-z8WLahOEDpRkPf6OvOYhjK6Mhl3Z4U4m536kAxUeFD5If0o1e2rdvSzD6oNPfs25rKs+UT7dla+4MSFU1JVjPA==}
 
-  '@vitest/spy@3.0.0-beta.3':
-    resolution: {integrity: sha512-IXvZL//Aq5UVIMFtvw1iYnk1iAjk9lGmQUw/fDqN7qMnb9SHfSRbhgxAph11n9nudgBlLiYPSY0nVfCpH/TQsA==}
+  '@vitest/spy@3.0.0-beta.4':
+    resolution: {integrity: sha512-3Re3ofS3cYq0rCgyiwk51gOzAZyQQ15caJHkuqjcF7dzK7zMGKZpjwQFDaMZq0eAq+AZg+Qo39qrDI8S1dIYSg==}
 
-  '@vitest/ui@3.0.0-beta.3':
-    resolution: {integrity: sha512-jg92y+waMY/72KA7/eHX1tOpfQk4ZsyouuFp4HJazFkAzSw+Co3lcw6/dcmH/WNB9KJgqjcPROQ/aa3509Azkw==}
+  '@vitest/ui@3.0.0-beta.4':
+    resolution: {integrity: sha512-ZZg8zzZ8Z6GIKthzBUYCagCkVQILLJKz7l/Le0ETQrw1sNYFRGpfTQ0GRtc26pUlMYVnj+qqp9wu5FKbPQbiSQ==}
     peerDependencies:
-      vitest: 3.0.0-beta.3
+      vitest: 3.0.0-beta.4
 
-  '@vitest/utils@3.0.0-beta.3':
-    resolution: {integrity: sha512-InEoZvpkcUTmg0J08/Phm6MLkQwWpf3RCJoqVuXiHK7OkUYW/EDoT0qfzL4MGo1PWq+UqIlMw93eAkkTf3RMvQ==}
+  '@vitest/utils@3.0.0-beta.4':
+    resolution: {integrity: sha512-ea90t+ajEQd5+jA60nuE5SemTlogk49T2Ttiq2ct2ZJpsSj4a7QEQBPsvWaqhKtE3+eVIhT4Qp/Mml2qqIMGEg==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -985,8 +986,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+  pathe@2.0.1:
+    resolution: {integrity: sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -1170,8 +1171,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  vite-node@3.0.0-beta.3:
-    resolution: {integrity: sha512-NqZk0TnqpaNwWEdu73IGRJ2PDg9TXiY0dRx6LHV64CY80JP3OcHb+YvbW4Xu6h/E+vU6qPFlwRuKYWG8Tdg4Gw==}
+  vite-node@3.0.0-beta.4:
+    resolution: {integrity: sha512-dzWen17ftEjmJWCsY7iMZ3lz4npzDsMYKEqkCnIiyABHiQCp9usrFnyzqNJJDIVZYZsG+UXgizOwjrV2cl2QYw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -1215,15 +1216,15 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.0.0-beta.3:
-    resolution: {integrity: sha512-e9miZwlVaMIAJ4MmCAxSeX4YWMyY4g+KRBjgSz0PL3UluSwHHUOWX/uUZwYmfPS4CvUr69RB1Dn6v61lgC+zCw==}
+  vitest@3.0.0-beta.4:
+    resolution: {integrity: sha512-lGRvQzzv4AOifGc7lhQ+s+1Bm0CtzLOZBwRIQiU6u9a968YTjxK5IGQLGJieI5OFh6V/Z+apsvCrm7CB29DkPw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.0.0-beta.3
-      '@vitest/ui': 3.0.0-beta.3
+      '@vitest/browser': 3.0.0-beta.4
+      '@vitest/ui': 3.0.0-beta.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -1282,7 +1283,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@bcoe/v8-coverage@0.2.3': {}
+  '@bcoe/v8-coverage@1.0.1': {}
 
   '@biomejs/biome@1.9.4':
     optionalDependencies:
@@ -1670,10 +1671,10 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  '@vitest/coverage-v8@3.0.0-beta.3(vitest@3.0.0-beta.3)':
+  '@vitest/coverage-v8@3.0.0-beta.4(vitest@3.0.0-beta.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 0.2.3
+      '@bcoe/v8-coverage': 1.0.1
       debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -1684,58 +1685,58 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 3.0.0-beta.3(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.3)
+      vitest: 3.0.0-beta.4(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.0.0-beta.3':
+  '@vitest/expect@3.0.0-beta.4':
     dependencies:
-      '@vitest/spy': 3.0.0-beta.3
-      '@vitest/utils': 3.0.0-beta.3
+      '@vitest/spy': 3.0.0-beta.4
+      '@vitest/utils': 3.0.0-beta.4
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@3.0.0-beta.3(vite@6.0.7(@types/node@22.10.5))':
+  '@vitest/mocker@3.0.0-beta.4(vite@6.0.7(@types/node@22.10.5))':
     dependencies:
-      '@vitest/spy': 3.0.0-beta.3
+      '@vitest/spy': 3.0.0-beta.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.0.7(@types/node@22.10.5)
 
-  '@vitest/pretty-format@3.0.0-beta.3':
+  '@vitest/pretty-format@3.0.0-beta.4':
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/runner@3.0.0-beta.3':
+  '@vitest/runner@3.0.0-beta.4':
     dependencies:
-      '@vitest/utils': 3.0.0-beta.3
-      pathe: 1.1.2
+      '@vitest/utils': 3.0.0-beta.4
+      pathe: 2.0.1
 
-  '@vitest/snapshot@3.0.0-beta.3':
+  '@vitest/snapshot@3.0.0-beta.4':
     dependencies:
-      '@vitest/pretty-format': 3.0.0-beta.3
+      '@vitest/pretty-format': 3.0.0-beta.4
       magic-string: 0.30.17
-      pathe: 1.1.2
+      pathe: 2.0.1
 
-  '@vitest/spy@3.0.0-beta.3':
+  '@vitest/spy@3.0.0-beta.4':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/ui@3.0.0-beta.3(vitest@3.0.0-beta.3)':
+  '@vitest/ui@3.0.0-beta.4(vitest@3.0.0-beta.4)':
     dependencies:
-      '@vitest/utils': 3.0.0-beta.3
+      '@vitest/utils': 3.0.0-beta.4
       fflate: 0.8.2
       flatted: 3.3.2
-      pathe: 1.1.2
+      pathe: 2.0.1
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 1.2.0
-      vitest: 3.0.0-beta.3(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.3)
+      vitest: 3.0.0-beta.4(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.4)
 
-  '@vitest/utils@3.0.0-beta.3':
+  '@vitest/utils@3.0.0-beta.4':
     dependencies:
-      '@vitest/pretty-format': 3.0.0-beta.3
+      '@vitest/pretty-format': 3.0.0-beta.4
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
@@ -2097,7 +2098,7 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.2: {}
+  pathe@2.0.1: {}
 
   pathval@2.0.0: {}
 
@@ -2263,12 +2264,12 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  vite-node@3.0.0-beta.3(@types/node@22.10.5):
+  vite-node@3.0.0-beta.4(@types/node@22.10.5):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
-      pathe: 1.1.2
+      pathe: 2.0.1
       vite: 6.0.7(@types/node@22.10.5)
     transitivePeerDependencies:
       - '@types/node'
@@ -2293,31 +2294,31 @@ snapshots:
       '@types/node': 22.10.5
       fsevents: 2.3.3
 
-  vitest@3.0.0-beta.3(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.3):
+  vitest@3.0.0-beta.4(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.4):
     dependencies:
-      '@vitest/expect': 3.0.0-beta.3
-      '@vitest/mocker': 3.0.0-beta.3(vite@6.0.7(@types/node@22.10.5))
-      '@vitest/pretty-format': 3.0.0-beta.3
-      '@vitest/runner': 3.0.0-beta.3
-      '@vitest/snapshot': 3.0.0-beta.3
-      '@vitest/spy': 3.0.0-beta.3
-      '@vitest/utils': 3.0.0-beta.3
+      '@vitest/expect': 3.0.0-beta.4
+      '@vitest/mocker': 3.0.0-beta.4(vite@6.0.7(@types/node@22.10.5))
+      '@vitest/pretty-format': 3.0.0-beta.4
+      '@vitest/runner': 3.0.0-beta.4
+      '@vitest/snapshot': 3.0.0-beta.4
+      '@vitest/spy': 3.0.0-beta.4
+      '@vitest/utils': 3.0.0-beta.4
       chai: 5.1.2
       debug: 4.4.0
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 1.1.2
+      pathe: 2.0.1
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
       vite: 6.0.7(@types/node@22.10.5)
-      vite-node: 3.0.0-beta.3(@types/node@22.10.5)
+      vite-node: 3.0.0-beta.4(@types/node@22.10.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.10.5
-      '@vitest/ui': 3.0.0-beta.3(vitest@3.0.0-beta.3)
+      '@vitest/ui': 3.0.0-beta.4(vitest@3.0.0-beta.4)
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 3.0.0-beta.3
       version: 3.0.0-beta.3
     effect:
-      specifier: 3.12.0
-      version: 3.12.0
+      specifier: 3.12.1
+      version: 3.12.1
     typescript:
       specifier: 5.7.3
       version: 5.7.3
@@ -88,7 +88,7 @@ importers:
         version: 22.10.5
       effect:
         specifier: 'catalog:'
-        version: 3.12.0
+        version: 3.12.1
       vitest:
         specifier: 'catalog:'
         version: 3.0.0-beta.3(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.3)
@@ -103,7 +103,7 @@ importers:
         version: 22.10.5
       effect:
         specifier: 'catalog:'
-        version: 3.12.0
+        version: 3.12.1
       vitest:
         specifier: 'catalog:'
         version: 3.0.0-beta.3(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.3)
@@ -705,8 +705,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  effect@3.12.0:
-    resolution: {integrity: sha512-b/u9s3b9HfTo0qygVouegP0hkbiuxRIeaCe1ppf8P88hPyl6lKCbErtn7Az4jG7LuU7f0Wgm4c8WXbMcL2j8+g==}
+  effect@3.12.1:
+    resolution: {integrity: sha512-aAZdh56Yp1ehOFYeMcHHctTtxfqm6kkOdZFTXK6Zf0QoaKKc1hPG6ocjrKOc0axE8JbG4eZw351ogNLrM4vo9w==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1815,7 +1815,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  effect@3.12.0:
+  effect@3.12.1:
     dependencies:
       fast-check: 3.23.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 3.12.0
       version: 3.12.0
     typescript:
-      specifier: 5.7.2
-      version: 5.7.2
+      specifier: 5.7.3
+      version: 5.7.3
     vitest:
       specifier: 3.0.0-beta.3
       version: 3.0.0-beta.3
@@ -70,7 +70,7 @@ importers:
         version: 3.0.0-beta.3(vitest@3.0.0-beta.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.7.2
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.0-beta.3(@types/node@22.10.5)(@vitest/ui@3.0.0-beta.3)
@@ -1158,8 +1158,8 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2257,7 +2257,7 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  typescript@5.7.2: {}
+  typescript@5.7.3: {}
 
   undici-types@6.20.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,5 +11,5 @@ catalog:
   "@vitest/coverage-v8": 3.0.0-beta.3
   "@vitest/ui": 3.0.0-beta.3
   effect: 3.12.0
-  typescript: 5.7.2
+  typescript: 5.7.3
   vitest: 3.0.0-beta.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,8 @@ catalog:
   "@tsconfig/strictest": 2.0.5
   "@types/json-schema": 7.0.15
   "@types/node": 22.10.5
-  "@vitest/coverage-v8": 3.0.0-beta.3
-  "@vitest/ui": 3.0.0-beta.3
+  "@vitest/coverage-v8": 3.0.0-beta.4
+  "@vitest/ui": 3.0.0-beta.4
   effect: 3.12.1
   typescript: 5.7.3
-  vitest: 3.0.0-beta.3
+  vitest: 3.0.0-beta.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,6 @@ catalog:
   "@types/node": 22.10.5
   "@vitest/coverage-v8": 3.0.0-beta.3
   "@vitest/ui": 3.0.0-beta.3
-  effect: 3.12.0
+  effect: 3.12.1
   typescript: 5.7.3
   vitest: 3.0.0-beta.3


### PR DESCRIPTION
This pull request includes updates to various dependencies across multiple files. The changes primarily focus on upgrading the versions of several packages to their latest beta versions.

Dependency updates:

* Updated dependencies in `.changeset/neat-drinks-check.md` to:
  * `@vitest/coverage-v8`: 3.0.0-beta.3 → 3.0.0-beta.4
  * `@vitest/ui`: 3.0.0-beta.3 → 3.0.0-beta.4
  * `effect`: 3.12.0 → 3.12.1
  * `vite-node`: 3.0.0-beta.3 → 3.0.0-beta.4
  * `vitest`: 3.0.0-beta.3 → 3.0.0-beta.4
  * [`typescript`](diffhunk://#diff-19b0188627b3d72d6d576f9b358b9f4750d4cdafdc0947a493fcdae2b8da862aR1-R11): 5.7.2 → 5.7.3

* Updated `packageManager` version in `package.json` from `pnpm@9.15.2` to `pnpm@9.15.3`

* Updated `effect` peer dependency in `packages/schema-resume/package.json` from `~3.12.0` to `~3.12.1`

* Updated multiple dependencies in `pnpm-lock.yaml`:
  * `@vitest/coverage-v8`, `@vitest/ui`, `effect`, `typescript`, `vite-node`, and `vitest` to their respective latest beta versions [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL31-R44) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL67-R76) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL91-R94) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL106-R109) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL138-R140) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL566-R580) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL589-R608) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL708-R710) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL988-R990) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1161-R1163) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1173-R1175) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1218-R1227) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1285-R1286) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1673-R1677) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1687-R1739) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1818-R1819) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2100-R2101) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2260-R2272) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2296-R2321)

* Updated `pnpm-workspace.yaml` to reflect the new versions of `@vitest/coverage-v8`, `@vitest/ui`, `effect`, `typescript`, and `vitest`