### PR TITLE
Update dependencies and lockfile for `schema-resume`

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,22 +1,13 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@suddenly-giovanni/schema-resume@0.0.4": "0.0.4",
     "npm:@deno/vite-plugin@1.0.3": "1.0.3_vite@6.1.0__@types+node@22.13.1__yaml@2.7.0_@types+node@22.13.1_yaml@2.7.0",
     "npm:@types/json-schema@7.0.15": "7.0.15",
     "npm:@types/node@22.13.1": "22.13.1",
     "npm:@vitest/coverage-istanbul@3.0.5": "3.0.5_vitest@3.0.5__@types+node@22.13.1__vite@6.1.0___@types+node@22.13.1___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.1_yaml@2.7.0",
-    "npm:effect@3.12.9": "3.12.9",
+    "npm:effect@~3.12.10": "3.12.10",
     "npm:vitest@3.0.5": "3.0.5_@types+node@22.13.1_vite@6.1.0__@types+node@22.13.1__yaml@2.7.0_yaml@2.7.0",
     "npm:yaml@2.7.0": "2.7.0"
-  },
-  "jsr": {
-    "@suddenly-giovanni/schema-resume@0.0.4": {
-      "integrity": "f091e28931e6c48aa4020d07b3c9d4036e17eb994e338ea5e38adc71e2bb3af3",
-      "dependencies": [
-        "npm:effect"
-      ]
-    }
   },
   "npm": {
     "@ampproject/remapping@2.3.0": {
@@ -489,8 +480,8 @@
     "eastasianwidth@0.2.0": {
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
-    "effect@3.12.9": {
-      "integrity": "sha512-u3PsO0KWtCTO56yGGYaa8RLOccE6Kbeb4UotS/ArAG/tqAyf0x3JF3WaaklhnxJtt67P6SktLmwRPT4hiuhKEA==",
+    "effect@3.12.10": {
+      "integrity": "sha512-fGg3sEN+l1rffWJvXICBTqyyzpa4y1uNo3aI/JLezJDmDk0Qj/WHiy6wVe0cecdr0eFU0XkZcFu2TWpgV8kBiw==",
       "dependencies": [
         "fast-check"
       ]
@@ -946,10 +937,9 @@
     "members": {
       "packages/resume": {
         "dependencies": [
-          "jsr:@suddenly-giovanni/schema-resume@0.0.4",
           "npm:@deno/vite-plugin@1.0.3",
           "npm:@types/node@22.13.1",
-          "npm:effect@3.12.9",
+          "npm:effect@~3.12.10",
           "npm:vitest@3.0.5",
           "npm:yaml@2.7.0"
         ]
@@ -959,7 +949,7 @@
           "npm:@deno/vite-plugin@1.0.3",
           "npm:@types/json-schema@7.0.15",
           "npm:@types/node@22.13.1",
-          "npm:effect@3.12.9",
+          "npm:effect@~3.12.10",
           "npm:vitest@3.0.5"
         ]
       }

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@suddenly-giovanni/schema-resume@0.0.4": "0.0.4",
     "npm:@deno/vite-plugin@1.0.3": "1.0.3_vite@6.1.0__@types+node@22.13.1__yaml@2.7.0_@types+node@22.13.1_yaml@2.7.0",
     "npm:@types/json-schema@7.0.15": "7.0.15",
     "npm:@types/node@22.13.1": "22.13.1",
@@ -8,6 +9,14 @@
     "npm:effect@3.12.9": "3.12.9",
     "npm:vitest@3.0.5": "3.0.5_@types+node@22.13.1_vite@6.1.0__@types+node@22.13.1__yaml@2.7.0_yaml@2.7.0",
     "npm:yaml@2.7.0": "2.7.0"
+  },
+  "jsr": {
+    "@suddenly-giovanni/schema-resume@0.0.4": {
+      "integrity": "f091e28931e6c48aa4020d07b3c9d4036e17eb994e338ea5e38adc71e2bb3af3",
+      "dependencies": [
+        "npm:effect"
+      ]
+    }
   },
   "npm": {
     "@ampproject/remapping@2.3.0": {

--- a/packages/resume/deno.json
+++ b/packages/resume/deno.json
@@ -3,9 +3,8 @@
 	"version": "0.0.2",
 	"imports": {
 		"@deno/vite-plugin": "npm:@deno/vite-plugin@1.0.3",
-		"@suddenly-giovanni/schema-resume": "jsr:@suddenly-giovanni/schema-resume@0.0.4",
 		"@types/node": "npm:@types/node@22.13.1",
-		"effect": "npm:effect@3.12.9",
+		"effect": "npm:effect@~3.12.10",
 		"vitest": "npm:vitest@3.0.5",
 		"yaml": "npm:yaml@2.7.0"
 	},

--- a/packages/schema-resume/deno.json
+++ b/packages/schema-resume/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/refs/heads/main/cli/schemas/config-file.v1.json",
 	"name": "@suddenly-giovanni/schema-resume",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"license": "MIT",
 	"exports": "./src/index.ts",
 	"publish": {
@@ -12,7 +12,7 @@
 		"@deno/vite-plugin": "npm:@deno/vite-plugin@1.0.3",
 		"@types/json-schema": "npm:@types/json-schema@7.0.15",
 		"@types/node": "npm:@types/node@22.13.1",
-		"effect": "npm:effect@3.12.9",
+		"effect": "npm:effect@~3.12.10",
 		"vitest": "npm:vitest@3.0.5"
 	},
 	"tasks": {


### PR DESCRIPTION
### Description
- Updated `effect` dependency to `~3.12.10` and removed `jsr` dependency from `schema-resume`.
- Incremented `schema-resume` package version to `0.0.5`.
- Updated `deno.lock` with the new `@suddenly-giovanni/schema-resume@0.0.4` dependency for proper integrity resolution. 

### Checklist
- [ ] Tests