### PR TITLE
Renovate/deps

### DIFF
--- a/.idea/deno.xml
+++ b/.idea/deno.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="DenoSettings">
     <option name="enableFormatting" value="false" />
-    <option name="useDenoValue" value="ENABLE" />
   </component>
 </project>

--- a/deno.json
+++ b/deno.json
@@ -32,7 +32,7 @@
 	},
 	"tasks": {
 		"test:all": {
-			"command": "deno run -A --inspect npm:vitest@3.0.8",
+			"command": "deno run -A --inspect npm:vitest@3.1.1",
 			"description": "Run all the project tests with vitest"
 		}
 	},

--- a/deno.json
+++ b/deno.json
@@ -38,8 +38,8 @@
 	},
 	"imports": {
 		"@deno/vite-plugin": "npm:@deno/vite-plugin@1.0.4",
-		"@types/node": "npm:@types/node@22.13.10",
-		"@vitest/coverage-istanbul": "npm:@vitest/coverage-istanbul@3.0.8",
-		"vitest": "npm:vitest@3.0.8"
+		"@types/node": "npm:@types/node@22.14.1",
+		"@vitest/coverage-istanbul": "npm:@vitest/coverage-istanbul@3.1.1",
+		"vitest": "npm:vitest@3.1.1"
 	}
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,14 +1,14 @@
 {
   "version": "4",
   "specifiers": {
-    "npm:@deno/vite-plugin@1.0.4": "1.0.4_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
+    "npm:@deno/vite-plugin@1.0.4": "1.0.4_vite@6.3.1__@types+node@22.13.10__yaml@2.7.1__picomatch@4.0.2_@types+node@22.13.10_yaml@2.7.1",
     "npm:@types/json-schema@7.0.15": "7.0.15",
     "npm:@types/node@22.13.10": "22.13.10",
     "npm:@types/node@22.14.1": "22.14.1",
-    "npm:@vitest/coverage-istanbul@3.1.1": "3.1.1_vitest@3.1.1__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
+    "npm:@vitest/coverage-istanbul@3.1.1": "3.1.1_vitest@3.1.1__@types+node@22.13.10__vite@6.3.1___@types+node@22.13.10___yaml@2.7.1___picomatch@4.0.2__yaml@2.7.1_@types+node@22.13.10_yaml@2.7.1",
     "npm:effect@~3.13.10": "3.13.10",
-    "npm:vitest@3.1.1": "3.1.1_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0",
-    "npm:yaml@2.7.0": "2.7.0"
+    "npm:vitest@3.1.1": "3.1.1_@types+node@22.13.10_vite@6.3.1__@types+node@22.13.10__yaml@2.7.1__picomatch@4.0.2_yaml@2.7.1",
+    "npm:yaml@2.7.1": "2.7.1"
   },
   "npm": {
     "@ampproject/remapping@2.3.0": {
@@ -134,86 +134,86 @@
         "@babel/helper-validator-identifier"
       ]
     },
-    "@deno/vite-plugin@1.0.4_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
+    "@deno/vite-plugin@1.0.4_vite@6.3.1__@types+node@22.13.10__yaml@2.7.1__picomatch@4.0.2_@types+node@22.13.10_yaml@2.7.1": {
       "integrity": "sha512-xg8YT8Wn2sGXSnJgiGTpBGX1Dov0c6fd1rAp8VsfrCUtyBRRWzwVMAnd3fQ4yq8h7LSVvJUxEFN4U421k/DQLA==",
       "dependencies": [
         "vite"
       ]
     },
-    "@esbuild/aix-ppc64@0.25.1": {
-      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ=="
+    "@esbuild/aix-ppc64@0.25.2": {
+      "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag=="
     },
-    "@esbuild/android-arm64@0.25.1": {
-      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA=="
+    "@esbuild/android-arm64@0.25.2": {
+      "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w=="
     },
-    "@esbuild/android-arm@0.25.1": {
-      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q=="
+    "@esbuild/android-arm@0.25.2": {
+      "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA=="
     },
-    "@esbuild/android-x64@0.25.1": {
-      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw=="
+    "@esbuild/android-x64@0.25.2": {
+      "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg=="
     },
-    "@esbuild/darwin-arm64@0.25.1": {
-      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ=="
+    "@esbuild/darwin-arm64@0.25.2": {
+      "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA=="
     },
-    "@esbuild/darwin-x64@0.25.1": {
-      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA=="
+    "@esbuild/darwin-x64@0.25.2": {
+      "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA=="
     },
-    "@esbuild/freebsd-arm64@0.25.1": {
-      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A=="
+    "@esbuild/freebsd-arm64@0.25.2": {
+      "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w=="
     },
-    "@esbuild/freebsd-x64@0.25.1": {
-      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww=="
+    "@esbuild/freebsd-x64@0.25.2": {
+      "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ=="
     },
-    "@esbuild/linux-arm64@0.25.1": {
-      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ=="
+    "@esbuild/linux-arm64@0.25.2": {
+      "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g=="
     },
-    "@esbuild/linux-arm@0.25.1": {
-      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ=="
+    "@esbuild/linux-arm@0.25.2": {
+      "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g=="
     },
-    "@esbuild/linux-ia32@0.25.1": {
-      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ=="
+    "@esbuild/linux-ia32@0.25.2": {
+      "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ=="
     },
-    "@esbuild/linux-loong64@0.25.1": {
-      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg=="
+    "@esbuild/linux-loong64@0.25.2": {
+      "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w=="
     },
-    "@esbuild/linux-mips64el@0.25.1": {
-      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg=="
+    "@esbuild/linux-mips64el@0.25.2": {
+      "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q=="
     },
-    "@esbuild/linux-ppc64@0.25.1": {
-      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg=="
+    "@esbuild/linux-ppc64@0.25.2": {
+      "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g=="
     },
-    "@esbuild/linux-riscv64@0.25.1": {
-      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ=="
+    "@esbuild/linux-riscv64@0.25.2": {
+      "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw=="
     },
-    "@esbuild/linux-s390x@0.25.1": {
-      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ=="
+    "@esbuild/linux-s390x@0.25.2": {
+      "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q=="
     },
-    "@esbuild/linux-x64@0.25.1": {
-      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA=="
+    "@esbuild/linux-x64@0.25.2": {
+      "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg=="
     },
-    "@esbuild/netbsd-arm64@0.25.1": {
-      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g=="
+    "@esbuild/netbsd-arm64@0.25.2": {
+      "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw=="
     },
-    "@esbuild/netbsd-x64@0.25.1": {
-      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA=="
+    "@esbuild/netbsd-x64@0.25.2": {
+      "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg=="
     },
-    "@esbuild/openbsd-arm64@0.25.1": {
-      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg=="
+    "@esbuild/openbsd-arm64@0.25.2": {
+      "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg=="
     },
-    "@esbuild/openbsd-x64@0.25.1": {
-      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw=="
+    "@esbuild/openbsd-x64@0.25.2": {
+      "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw=="
     },
-    "@esbuild/sunos-x64@0.25.1": {
-      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg=="
+    "@esbuild/sunos-x64@0.25.2": {
+      "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA=="
     },
-    "@esbuild/win32-arm64@0.25.1": {
-      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ=="
+    "@esbuild/win32-arm64@0.25.2": {
+      "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q=="
     },
-    "@esbuild/win32-ia32@0.25.1": {
-      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A=="
+    "@esbuild/win32-ia32@0.25.2": {
+      "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg=="
     },
-    "@esbuild/win32-x64@0.25.1": {
-      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg=="
+    "@esbuild/win32-x64@0.25.2": {
+      "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA=="
     },
     "@isaacs/cliui@8.0.2": {
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
@@ -256,68 +256,71 @@
     "@pkgjs/parseargs@0.11.0": {
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="
     },
-    "@rollup/rollup-android-arm-eabi@4.35.0": {
-      "integrity": "sha512-uYQ2WfPaqz5QtVgMxfN6NpLD+no0MYHDBywl7itPYd3K5TjjSghNKmX8ic9S8NU8w81NVhJv/XojcHptRly7qQ=="
+    "@rollup/rollup-android-arm-eabi@4.40.0": {
+      "integrity": "sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg=="
     },
-    "@rollup/rollup-android-arm64@4.35.0": {
-      "integrity": "sha512-FtKddj9XZudurLhdJnBl9fl6BwCJ3ky8riCXjEw3/UIbjmIY58ppWwPEvU3fNu+W7FUsAsB1CdH+7EQE6CXAPA=="
+    "@rollup/rollup-android-arm64@4.40.0": {
+      "integrity": "sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w=="
     },
-    "@rollup/rollup-darwin-arm64@4.35.0": {
-      "integrity": "sha512-Uk+GjOJR6CY844/q6r5DR/6lkPFOw0hjfOIzVx22THJXMxktXG6CbejseJFznU8vHcEBLpiXKY3/6xc+cBm65Q=="
+    "@rollup/rollup-darwin-arm64@4.40.0": {
+      "integrity": "sha512-GwYOcOakYHdfnjjKwqpTGgn5a6cUX7+Ra2HeNj/GdXvO2VJOOXCiYYlRFU4CubFM67EhbmzLOmACKEfvp3J1kQ=="
     },
-    "@rollup/rollup-darwin-x64@4.35.0": {
-      "integrity": "sha512-3IrHjfAS6Vkp+5bISNQnPogRAW5GAV1n+bNCrDwXmfMHbPl5EhTmWtfmwlJxFRUCBZ+tZ/OxDyU08aF6NI/N5Q=="
+    "@rollup/rollup-darwin-x64@4.40.0": {
+      "integrity": "sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA=="
     },
-    "@rollup/rollup-freebsd-arm64@4.35.0": {
-      "integrity": "sha512-sxjoD/6F9cDLSELuLNnY0fOrM9WA0KrM0vWm57XhrIMf5FGiN8D0l7fn+bpUeBSU7dCgPV2oX4zHAsAXyHFGcQ=="
+    "@rollup/rollup-freebsd-arm64@4.40.0": {
+      "integrity": "sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg=="
     },
-    "@rollup/rollup-freebsd-x64@4.35.0": {
-      "integrity": "sha512-2mpHCeRuD1u/2kruUiHSsnjWtHjqVbzhBkNVQ1aVD63CcexKVcQGwJ2g5VphOd84GvxfSvnnlEyBtQCE5hxVVw=="
+    "@rollup/rollup-freebsd-x64@4.40.0": {
+      "integrity": "sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw=="
     },
-    "@rollup/rollup-linux-arm-gnueabihf@4.35.0": {
-      "integrity": "sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg=="
+    "@rollup/rollup-linux-arm-gnueabihf@4.40.0": {
+      "integrity": "sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA=="
     },
-    "@rollup/rollup-linux-arm-musleabihf@4.35.0": {
-      "integrity": "sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A=="
+    "@rollup/rollup-linux-arm-musleabihf@4.40.0": {
+      "integrity": "sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg=="
     },
-    "@rollup/rollup-linux-arm64-gnu@4.35.0": {
-      "integrity": "sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A=="
+    "@rollup/rollup-linux-arm64-gnu@4.40.0": {
+      "integrity": "sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg=="
     },
-    "@rollup/rollup-linux-arm64-musl@4.35.0": {
-      "integrity": "sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg=="
+    "@rollup/rollup-linux-arm64-musl@4.40.0": {
+      "integrity": "sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ=="
     },
-    "@rollup/rollup-linux-loongarch64-gnu@4.35.0": {
-      "integrity": "sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g=="
+    "@rollup/rollup-linux-loongarch64-gnu@4.40.0": {
+      "integrity": "sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg=="
     },
-    "@rollup/rollup-linux-powerpc64le-gnu@4.35.0": {
-      "integrity": "sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA=="
+    "@rollup/rollup-linux-powerpc64le-gnu@4.40.0": {
+      "integrity": "sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw=="
     },
-    "@rollup/rollup-linux-riscv64-gnu@4.35.0": {
-      "integrity": "sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g=="
+    "@rollup/rollup-linux-riscv64-gnu@4.40.0": {
+      "integrity": "sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA=="
     },
-    "@rollup/rollup-linux-s390x-gnu@4.35.0": {
-      "integrity": "sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw=="
+    "@rollup/rollup-linux-riscv64-musl@4.40.0": {
+      "integrity": "sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ=="
     },
-    "@rollup/rollup-linux-x64-gnu@4.35.0": {
-      "integrity": "sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA=="
+    "@rollup/rollup-linux-s390x-gnu@4.40.0": {
+      "integrity": "sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw=="
     },
-    "@rollup/rollup-linux-x64-musl@4.35.0": {
-      "integrity": "sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg=="
+    "@rollup/rollup-linux-x64-gnu@4.40.0": {
+      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ=="
     },
-    "@rollup/rollup-win32-arm64-msvc@4.35.0": {
-      "integrity": "sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg=="
+    "@rollup/rollup-linux-x64-musl@4.40.0": {
+      "integrity": "sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw=="
     },
-    "@rollup/rollup-win32-ia32-msvc@4.35.0": {
-      "integrity": "sha512-2/lsgejMrtwQe44glq7AFFHLfJBPafpsTa6JvP2NGef/ifOa4KBoglVf7AKN7EV9o32evBPRqfg96fEHzWo5kw=="
+    "@rollup/rollup-win32-arm64-msvc@4.40.0": {
+      "integrity": "sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ=="
     },
-    "@rollup/rollup-win32-x64-msvc@4.35.0": {
-      "integrity": "sha512-PIQeY5XDkrOysbQblSW7v3l1MDZzkTEzAfTPkj5VAu3FW8fS4ynyLg2sINp0fp3SjZ8xkRYpLqoKcYqAkhU1dw=="
+    "@rollup/rollup-win32-ia32-msvc@4.40.0": {
+      "integrity": "sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA=="
+    },
+    "@rollup/rollup-win32-x64-msvc@4.40.0": {
+      "integrity": "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ=="
     },
     "@standard-schema/spec@1.0.0": {
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
     },
-    "@types/estree@1.0.6": {
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+    "@types/estree@1.0.7": {
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
     },
     "@types/json-schema@7.0.15": {
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
@@ -334,7 +337,7 @@
         "undici-types@6.21.0"
       ]
     },
-    "@vitest/coverage-istanbul@3.1.1_vitest@3.1.1__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
+    "@vitest/coverage-istanbul@3.1.1_vitest@3.1.1__@types+node@22.13.10__vite@6.3.1___@types+node@22.13.10___yaml@2.7.1___picomatch@4.0.2__yaml@2.7.1_@types+node@22.13.10_yaml@2.7.1": {
       "integrity": "sha512-uSoMeVcF5fMGcjWJOeG28nBPO2OuCNMRr+BcpF71gc1r/+EQnU7EeRM1hihs3EsSAOcjgw9w+TCMv/2lVvB4RA==",
       "dependencies": [
         "@istanbuljs/schema",
@@ -359,7 +362,7 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@3.1.1_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
+    "@vitest/mocker@3.1.1_vite@6.3.1__@types+node@22.13.10__yaml@2.7.1__picomatch@4.0.2_@types+node@22.13.10_yaml@2.7.1": {
       "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
       "dependencies": [
         "@vitest/spy",
@@ -509,8 +512,8 @@
     "es-module-lexer@1.6.0": {
       "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ=="
     },
-    "esbuild@0.25.1": {
-      "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
+    "esbuild@0.25.2": {
+      "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
       "dependencies": [
         "@esbuild/aix-ppc64",
         "@esbuild/android-arm",
@@ -548,13 +551,19 @@
         "@types/estree"
       ]
     },
-    "expect-type@1.2.0": {
-      "integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA=="
+    "expect-type@1.2.1": {
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw=="
     },
     "fast-check@3.23.2": {
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
       "dependencies": [
         "pure-rand"
+      ]
+    },
+    "fdir@6.4.3_picomatch@4.0.2": {
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "dependencies": [
+        "picomatch"
       ]
     },
     "foreground-child@3.3.1": {
@@ -692,8 +701,8 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "nanoid@3.3.9": {
-      "integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg=="
+    "nanoid@3.3.11": {
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
     },
     "node-releases@2.0.19": {
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
@@ -720,6 +729,9 @@
     "picocolors@1.1.1": {
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
+    "picomatch@4.0.2": {
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="
+    },
     "postcss@8.5.3": {
       "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "dependencies": [
@@ -731,8 +743,8 @@
     "pure-rand@6.1.0": {
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="
     },
-    "rollup@4.35.0": {
-      "integrity": "sha512-kg6oI4g+vc41vePJyO6dHt/yl0Rz3Thv0kJeVQ3D1kS3E5XSuKbPc29G4IpT/Kv1KQwgHVcN+HtyS+HYLNSvQg==",
+    "rollup@4.40.0": {
+      "integrity": "sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==",
       "dependencies": [
         "@rollup/rollup-android-arm-eabi",
         "@rollup/rollup-android-arm64",
@@ -747,6 +759,7 @@
         "@rollup/rollup-linux-loongarch64-gnu",
         "@rollup/rollup-linux-powerpc64le-gnu",
         "@rollup/rollup-linux-riscv64-gnu",
+        "@rollup/rollup-linux-riscv64-musl",
         "@rollup/rollup-linux-s390x-gnu",
         "@rollup/rollup-linux-x64-gnu",
         "@rollup/rollup-linux-x64-musl",
@@ -784,8 +797,8 @@
     "stackback@0.0.2": {
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
     },
-    "std-env@3.8.1": {
-      "integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA=="
+    "std-env@3.9.0": {
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="
     },
     "string-width@4.2.3": {
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -835,6 +848,13 @@
     "tinyexec@0.3.2": {
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
     },
+    "tinyglobby@0.2.12_picomatch@4.0.2": {
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "dependencies": [
+        "fdir",
+        "picomatch"
+      ]
+    },
     "tinypool@1.0.2": {
       "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA=="
     },
@@ -858,7 +878,7 @@
         "picocolors"
       ]
     },
-    "vite-node@3.1.1_@types+node@22.13.10_yaml@2.7.0": {
+    "vite-node@3.1.1_@types+node@22.13.10_yaml@2.7.1": {
       "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
       "dependencies": [
         "cac",
@@ -868,18 +888,21 @@
         "vite"
       ]
     },
-    "vite@6.2.2_@types+node@22.13.10_yaml@2.7.0": {
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+    "vite@6.3.1_@types+node@22.13.10_yaml@2.7.1_picomatch@4.0.2": {
+      "integrity": "sha512-kkzzkqtMESYklo96HKKPE5KKLkC1amlsqt+RjFMlX2AvbRB/0wghap19NdBxxwGZ+h/C6DLCrcEphPIItlGrRQ==",
       "dependencies": [
         "@types/node@22.13.10",
         "esbuild",
+        "fdir",
         "fsevents",
+        "picomatch",
         "postcss",
         "rollup",
+        "tinyglobby",
         "yaml"
       ]
     },
-    "vitest@3.1.1_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0": {
+    "vitest@3.1.1_@types+node@22.13.10_vite@6.3.1__@types+node@22.13.10__yaml@2.7.1__picomatch@4.0.2_yaml@2.7.1": {
       "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
       "dependencies": [
         "@types/node@22.13.10",
@@ -937,8 +960,8 @@
     "yallist@3.1.1": {
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
-    "yaml@2.7.0": {
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA=="
+    "yaml@2.7.1": {
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="
     }
   },
   "workspace": {
@@ -955,7 +978,7 @@
           "npm:@types/node@22.13.10",
           "npm:effect@~3.13.10",
           "npm:vitest@3.1.1",
-          "npm:yaml@2.7.0"
+          "npm:yaml@2.7.1"
         ]
       },
       "packages/schema-resume": {

--- a/deno.lock
+++ b/deno.lock
@@ -4,9 +4,11 @@
     "npm:@deno/vite-plugin@1.0.4": "1.0.4_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
     "npm:@types/json-schema@7.0.15": "7.0.15",
     "npm:@types/node@22.13.10": "22.13.10",
-    "npm:@vitest/coverage-istanbul@3.0.8": "3.0.8_vitest@3.0.8__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
+    "npm:@types/node@22.14.1": "22.14.1",
+    "npm:@vitest/coverage-istanbul@3.1.1": "3.1.1_vitest@3.0.8__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
     "npm:effect@~3.13.10": "3.13.10",
     "npm:vitest@3.0.8": "3.0.8_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0",
+    "npm:vitest@3.1.1": "3.1.1_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0",
     "npm:yaml@2.7.0": "2.7.0"
   },
   "npm": {
@@ -48,8 +50,8 @@
         "semver@6.3.1"
       ]
     },
-    "@babel/generator@7.26.10": {
-      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
+    "@babel/generator@7.27.0": {
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
       "dependencies": [
         "@babel/parser",
         "@babel/types",
@@ -58,8 +60,8 @@
         "jsesc"
       ]
     },
-    "@babel/helper-compilation-targets@7.26.5": {
-      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
+    "@babel/helper-compilation-targets@7.27.0": {
+      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
       "dependencies": [
         "@babel/compat-data",
         "@babel/helper-validator-option",
@@ -93,29 +95,29 @@
     "@babel/helper-validator-option@7.25.9": {
       "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw=="
     },
-    "@babel/helpers@7.26.10": {
-      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
+    "@babel/helpers@7.27.0": {
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dependencies": [
         "@babel/template",
         "@babel/types"
       ]
     },
-    "@babel/parser@7.26.10": {
-      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
+    "@babel/parser@7.27.0": {
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dependencies": [
         "@babel/types"
       ]
     },
-    "@babel/template@7.26.9": {
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+    "@babel/template@7.27.0": {
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dependencies": [
         "@babel/code-frame",
         "@babel/parser",
         "@babel/types"
       ]
     },
-    "@babel/traverse@7.26.10": {
-      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
+    "@babel/traverse@7.27.0": {
+      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
       "dependencies": [
         "@babel/code-frame",
         "@babel/generator",
@@ -126,8 +128,8 @@
         "globals"
       ]
     },
-    "@babel/types@7.26.10": {
-      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
+    "@babel/types@7.27.0": {
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dependencies": [
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
@@ -324,11 +326,17 @@
     "@types/node@22.13.10": {
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dependencies": [
-        "undici-types"
+        "undici-types@6.20.0"
       ]
     },
-    "@vitest/coverage-istanbul@3.0.8_vitest@3.0.8__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
-      "integrity": "sha512-v/frNs3RF//gQP/+AkXG2Bk51qiK1bGRubq/vgM7CxEw40Jl3N9rMpgAOAz8ELL9HAWvAZ9fswR8YyHhO1HxSQ==",
+    "@types/node@22.14.1": {
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "dependencies": [
+        "undici-types@6.21.0"
+      ]
+    },
+    "@vitest/coverage-istanbul@3.1.1_vitest@3.0.8__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
+      "integrity": "sha512-uSoMeVcF5fMGcjWJOeG28nBPO2OuCNMRr+BcpF71gc1r/+EQnU7EeRM1hihs3EsSAOcjgw9w+TCMv/2lVvB4RA==",
       "dependencies": [
         "@istanbuljs/schema",
         "debug",
@@ -340,14 +348,23 @@
         "magicast",
         "test-exclude",
         "tinyrainbow",
-        "vitest"
+        "vitest@3.0.8_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0"
       ]
     },
     "@vitest/expect@3.0.8": {
       "integrity": "sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==",
       "dependencies": [
-        "@vitest/spy",
-        "@vitest/utils",
+        "@vitest/spy@3.0.8",
+        "@vitest/utils@3.0.8",
+        "chai",
+        "tinyrainbow"
+      ]
+    },
+    "@vitest/expect@3.1.1": {
+      "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
+      "dependencies": [
+        "@vitest/spy@3.1.1",
+        "@vitest/utils@3.1.1",
         "chai",
         "tinyrainbow"
       ]
@@ -355,7 +372,16 @@
     "@vitest/mocker@3.0.8_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
       "integrity": "sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==",
       "dependencies": [
-        "@vitest/spy",
+        "@vitest/spy@3.0.8",
+        "estree-walker",
+        "magic-string",
+        "vite"
+      ]
+    },
+    "@vitest/mocker@3.1.1_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
+      "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
+      "dependencies": [
+        "@vitest/spy@3.1.1",
         "estree-walker",
         "magic-string",
         "vite"
@@ -367,17 +393,38 @@
         "tinyrainbow"
       ]
     },
+    "@vitest/pretty-format@3.1.1": {
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+      "dependencies": [
+        "tinyrainbow"
+      ]
+    },
     "@vitest/runner@3.0.8": {
       "integrity": "sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==",
       "dependencies": [
-        "@vitest/utils",
+        "@vitest/utils@3.0.8",
+        "pathe"
+      ]
+    },
+    "@vitest/runner@3.1.1": {
+      "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
+      "dependencies": [
+        "@vitest/utils@3.1.1",
         "pathe"
       ]
     },
     "@vitest/snapshot@3.0.8": {
       "integrity": "sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==",
       "dependencies": [
-        "@vitest/pretty-format",
+        "@vitest/pretty-format@3.0.8",
+        "magic-string",
+        "pathe"
+      ]
+    },
+    "@vitest/snapshot@3.1.1": {
+      "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
+      "dependencies": [
+        "@vitest/pretty-format@3.1.1",
         "magic-string",
         "pathe"
       ]
@@ -388,10 +435,24 @@
         "tinyspy"
       ]
     },
+    "@vitest/spy@3.1.1": {
+      "integrity": "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==",
+      "dependencies": [
+        "tinyspy"
+      ]
+    },
     "@vitest/utils@3.0.8": {
       "integrity": "sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==",
       "dependencies": [
-        "@vitest/pretty-format",
+        "@vitest/pretty-format@3.0.8",
+        "loupe",
+        "tinyrainbow"
+      ]
+    },
+    "@vitest/utils@3.1.1": {
+      "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
+      "dependencies": [
+        "@vitest/pretty-format@3.1.1",
         "loupe",
         "tinyrainbow"
       ]
@@ -435,8 +496,8 @@
     "cac@6.7.14": {
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="
     },
-    "caniuse-lite@1.0.30001704": {
-      "integrity": "sha512-+L2IgBbV6gXB4ETf0keSvLr7JUrRVbIaB/lrQ1+z8mRcQiisG5k+lG6O4n6Y5q6f5EuNfaYXKgymucphlEXQew=="
+    "caniuse-lite@1.0.30001714": {
+      "integrity": "sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg=="
     },
     "chai@5.2.0": {
       "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
@@ -490,8 +551,8 @@
         "fast-check"
       ]
     },
-    "electron-to-chromium@1.5.118": {
-      "integrity": "sha512-yNDUus0iultYyVoEFLnQeei7LOQkL8wg8GQpkPCRrOlJXlcCwa6eGKZkxQ9ciHsqZyYbj8Jd94X1CTPzGm+uIA=="
+    "electron-to-chromium@1.5.137": {
+      "integrity": "sha512-/QSJaU2JyIuTbbABAo/crOs+SuAZLS+fVVS10PVrIT9hrRkmZl8Hb0xPSkKRUUWHQtYzXHpQUW3Dy5hwMzGZkA=="
     },
     "emoji-regex@8.0.0": {
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
@@ -840,6 +901,9 @@
     "undici-types@6.20.0": {
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
+    "undici-types@6.21.0": {
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
     "update-browserslist-db@1.1.3_browserslist@4.24.4": {
       "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dependencies": [
@@ -858,10 +922,20 @@
         "vite"
       ]
     },
+    "vite-node@3.1.1_@types+node@22.13.10_yaml@2.7.0": {
+      "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
+      "dependencies": [
+        "cac",
+        "debug",
+        "es-module-lexer",
+        "pathe",
+        "vite"
+      ]
+    },
     "vite@6.2.2_@types+node@22.13.10_yaml@2.7.0": {
       "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
       "dependencies": [
-        "@types/node",
+        "@types/node@22.13.10",
         "esbuild",
         "fsevents",
         "postcss",
@@ -872,14 +946,14 @@
     "vitest@3.0.8_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0": {
       "integrity": "sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==",
       "dependencies": [
-        "@types/node",
-        "@vitest/expect",
-        "@vitest/mocker",
-        "@vitest/pretty-format",
-        "@vitest/runner",
-        "@vitest/snapshot",
-        "@vitest/spy",
-        "@vitest/utils",
+        "@types/node@22.13.10",
+        "@vitest/expect@3.0.8",
+        "@vitest/mocker@3.0.8_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
+        "@vitest/pretty-format@3.0.8",
+        "@vitest/runner@3.0.8",
+        "@vitest/snapshot@3.0.8",
+        "@vitest/spy@3.0.8",
+        "@vitest/utils@3.0.8",
         "chai",
         "debug",
         "expect-type",
@@ -891,7 +965,33 @@
         "tinypool",
         "tinyrainbow",
         "vite",
-        "vite-node",
+        "vite-node@3.0.8_@types+node@22.13.10_yaml@2.7.0",
+        "why-is-node-running"
+      ]
+    },
+    "vitest@3.1.1_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0": {
+      "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
+      "dependencies": [
+        "@types/node@22.13.10",
+        "@vitest/expect@3.1.1",
+        "@vitest/mocker@3.1.1_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
+        "@vitest/pretty-format@3.1.1",
+        "@vitest/runner@3.1.1",
+        "@vitest/snapshot@3.1.1",
+        "@vitest/spy@3.1.1",
+        "@vitest/utils@3.1.1",
+        "chai",
+        "debug",
+        "expect-type",
+        "magic-string",
+        "pathe",
+        "std-env",
+        "tinybench",
+        "tinyexec",
+        "tinypool",
+        "tinyrainbow",
+        "vite",
+        "vite-node@3.1.1_@types+node@22.13.10_yaml@2.7.0",
         "why-is-node-running"
       ]
     },
@@ -934,9 +1034,9 @@
   "workspace": {
     "dependencies": [
       "npm:@deno/vite-plugin@1.0.4",
-      "npm:@types/node@22.13.10",
-      "npm:@vitest/coverage-istanbul@3.0.8",
-      "npm:vitest@3.0.8"
+      "npm:@types/node@22.14.1",
+      "npm:@vitest/coverage-istanbul@3.1.1",
+      "npm:vitest@3.1.1"
     ],
     "members": {
       "packages/resume": {

--- a/deno.lock
+++ b/deno.lock
@@ -6,7 +6,7 @@
     "npm:@types/node@22.13.10": "22.13.10",
     "npm:@types/node@22.14.1": "22.14.1",
     "npm:@vitest/coverage-istanbul@3.1.1": "3.1.1_vitest@3.1.1__@types+node@22.13.10__vite@6.3.1___@types+node@22.13.10___yaml@2.7.1___picomatch@4.0.2__yaml@2.7.1_@types+node@22.13.10_yaml@2.7.1",
-    "npm:effect@~3.13.10": "3.13.10",
+    "npm:effect@^3.14.10": "3.14.10",
     "npm:vitest@3.1.1": "3.1.1_@types+node@22.13.10_vite@6.3.1__@types+node@22.13.10__yaml@2.7.1__picomatch@4.0.2_yaml@2.7.1",
     "npm:yaml@2.7.1": "2.7.1"
   },
@@ -493,8 +493,8 @@
     "eastasianwidth@0.2.0": {
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
-    "effect@3.13.10": {
-      "integrity": "sha512-f2n51BJJ25G9rb/C1ClkgsVFXH6YTkCHmd6ebpu6cAkwQxfhnfbkVWKgkn3nyW9YnC9z4K8bGohRYaZ+HyWtLg==",
+    "effect@3.14.10": {
+      "integrity": "sha512-qmqq8eqQlavxtOvDRtizbW5/Z2rSJA1U7vhrF5h+8gcCRVqYXj5nTyySUyHdMMEFPBjsgVeJ1aVKMXZGjaGoAg==",
       "dependencies": [
         "@standard-schema/spec",
         "fast-check"
@@ -976,7 +976,7 @@
         "dependencies": [
           "npm:@deno/vite-plugin@1.0.4",
           "npm:@types/node@22.14.1",
-          "npm:effect@~3.13.10",
+          "npm:effect@^3.14.10",
           "npm:vitest@3.1.1",
           "npm:yaml@2.7.1"
         ]
@@ -986,7 +986,7 @@
           "npm:@deno/vite-plugin@1.0.4",
           "npm:@types/json-schema@7.0.15",
           "npm:@types/node@22.14.1",
-          "npm:effect@~3.13.10",
+          "npm:effect@^3.14.10",
           "npm:vitest@3.1.1"
         ]
       }

--- a/deno.lock
+++ b/deno.lock
@@ -5,9 +5,8 @@
     "npm:@types/json-schema@7.0.15": "7.0.15",
     "npm:@types/node@22.13.10": "22.13.10",
     "npm:@types/node@22.14.1": "22.14.1",
-    "npm:@vitest/coverage-istanbul@3.1.1": "3.1.1_vitest@3.0.8__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
+    "npm:@vitest/coverage-istanbul@3.1.1": "3.1.1_vitest@3.1.1__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
     "npm:effect@~3.13.10": "3.13.10",
-    "npm:vitest@3.0.8": "3.0.8_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0",
     "npm:vitest@3.1.1": "3.1.1_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0",
     "npm:yaml@2.7.0": "2.7.0"
   },
@@ -335,7 +334,7 @@
         "undici-types@6.21.0"
       ]
     },
-    "@vitest/coverage-istanbul@3.1.1_vitest@3.0.8__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
+    "@vitest/coverage-istanbul@3.1.1_vitest@3.1.1__@types+node@22.13.10__vite@6.2.2___@types+node@22.13.10___yaml@2.7.0__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
       "integrity": "sha512-uSoMeVcF5fMGcjWJOeG28nBPO2OuCNMRr+BcpF71gc1r/+EQnU7EeRM1hihs3EsSAOcjgw9w+TCMv/2lVvB4RA==",
       "dependencies": [
         "@istanbuljs/schema",
@@ -348,49 +347,25 @@
         "magicast",
         "test-exclude",
         "tinyrainbow",
-        "vitest@3.0.8_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0"
-      ]
-    },
-    "@vitest/expect@3.0.8": {
-      "integrity": "sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==",
-      "dependencies": [
-        "@vitest/spy@3.0.8",
-        "@vitest/utils@3.0.8",
-        "chai",
-        "tinyrainbow"
+        "vitest"
       ]
     },
     "@vitest/expect@3.1.1": {
       "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
       "dependencies": [
-        "@vitest/spy@3.1.1",
-        "@vitest/utils@3.1.1",
+        "@vitest/spy",
+        "@vitest/utils",
         "chai",
         "tinyrainbow"
-      ]
-    },
-    "@vitest/mocker@3.0.8_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
-      "integrity": "sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==",
-      "dependencies": [
-        "@vitest/spy@3.0.8",
-        "estree-walker",
-        "magic-string",
-        "vite"
       ]
     },
     "@vitest/mocker@3.1.1_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0": {
       "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
       "dependencies": [
-        "@vitest/spy@3.1.1",
+        "@vitest/spy",
         "estree-walker",
         "magic-string",
         "vite"
-      ]
-    },
-    "@vitest/pretty-format@3.0.8": {
-      "integrity": "sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==",
-      "dependencies": [
-        "tinyrainbow"
       ]
     },
     "@vitest/pretty-format@3.1.1": {
@@ -399,40 +374,19 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/runner@3.0.8": {
-      "integrity": "sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==",
-      "dependencies": [
-        "@vitest/utils@3.0.8",
-        "pathe"
-      ]
-    },
     "@vitest/runner@3.1.1": {
       "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
       "dependencies": [
-        "@vitest/utils@3.1.1",
-        "pathe"
-      ]
-    },
-    "@vitest/snapshot@3.0.8": {
-      "integrity": "sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==",
-      "dependencies": [
-        "@vitest/pretty-format@3.0.8",
-        "magic-string",
+        "@vitest/utils",
         "pathe"
       ]
     },
     "@vitest/snapshot@3.1.1": {
       "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
       "dependencies": [
-        "@vitest/pretty-format@3.1.1",
+        "@vitest/pretty-format",
         "magic-string",
         "pathe"
-      ]
-    },
-    "@vitest/spy@3.0.8": {
-      "integrity": "sha512-MR+PzJa+22vFKYb934CejhR4BeRpMSoxkvNoDit68GQxRLSf11aT6CTj3XaqUU9rxgWJFnqicN/wxw6yBRkI1Q==",
-      "dependencies": [
-        "tinyspy"
       ]
     },
     "@vitest/spy@3.1.1": {
@@ -441,18 +395,10 @@
         "tinyspy"
       ]
     },
-    "@vitest/utils@3.0.8": {
-      "integrity": "sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==",
-      "dependencies": [
-        "@vitest/pretty-format@3.0.8",
-        "loupe",
-        "tinyrainbow"
-      ]
-    },
     "@vitest/utils@3.1.1": {
       "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
       "dependencies": [
-        "@vitest/pretty-format@3.1.1",
+        "@vitest/pretty-format",
         "loupe",
         "tinyrainbow"
       ]
@@ -912,16 +858,6 @@
         "picocolors"
       ]
     },
-    "vite-node@3.0.8_@types+node@22.13.10_yaml@2.7.0": {
-      "integrity": "sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==",
-      "dependencies": [
-        "cac",
-        "debug",
-        "es-module-lexer",
-        "pathe",
-        "vite"
-      ]
-    },
     "vite-node@3.1.1_@types+node@22.13.10_yaml@2.7.0": {
       "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
       "dependencies": [
@@ -943,43 +879,17 @@
         "yaml"
       ]
     },
-    "vitest@3.0.8_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0": {
-      "integrity": "sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==",
-      "dependencies": [
-        "@types/node@22.13.10",
-        "@vitest/expect@3.0.8",
-        "@vitest/mocker@3.0.8_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
-        "@vitest/pretty-format@3.0.8",
-        "@vitest/runner@3.0.8",
-        "@vitest/snapshot@3.0.8",
-        "@vitest/spy@3.0.8",
-        "@vitest/utils@3.0.8",
-        "chai",
-        "debug",
-        "expect-type",
-        "magic-string",
-        "pathe",
-        "std-env",
-        "tinybench",
-        "tinyexec",
-        "tinypool",
-        "tinyrainbow",
-        "vite",
-        "vite-node@3.0.8_@types+node@22.13.10_yaml@2.7.0",
-        "why-is-node-running"
-      ]
-    },
     "vitest@3.1.1_@types+node@22.13.10_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_yaml@2.7.0": {
       "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
       "dependencies": [
         "@types/node@22.13.10",
-        "@vitest/expect@3.1.1",
-        "@vitest/mocker@3.1.1_vite@6.2.2__@types+node@22.13.10__yaml@2.7.0_@types+node@22.13.10_yaml@2.7.0",
-        "@vitest/pretty-format@3.1.1",
-        "@vitest/runner@3.1.1",
-        "@vitest/snapshot@3.1.1",
-        "@vitest/spy@3.1.1",
-        "@vitest/utils@3.1.1",
+        "@vitest/expect",
+        "@vitest/mocker",
+        "@vitest/pretty-format",
+        "@vitest/runner",
+        "@vitest/snapshot",
+        "@vitest/spy",
+        "@vitest/utils",
         "chai",
         "debug",
         "expect-type",
@@ -991,7 +901,7 @@
         "tinypool",
         "tinyrainbow",
         "vite",
-        "vite-node@3.1.1_@types+node@22.13.10_yaml@2.7.0",
+        "vite-node",
         "why-is-node-running"
       ]
     },
@@ -1044,7 +954,7 @@
           "npm:@deno/vite-plugin@1.0.4",
           "npm:@types/node@22.13.10",
           "npm:effect@~3.13.10",
-          "npm:vitest@3.0.8",
+          "npm:vitest@3.1.1",
           "npm:yaml@2.7.0"
         ]
       },
@@ -1054,7 +964,7 @@
           "npm:@types/json-schema@7.0.15",
           "npm:@types/node@22.13.10",
           "npm:effect@~3.13.10",
-          "npm:vitest@3.0.8"
+          "npm:vitest@3.1.1"
         ]
       }
     }

--- a/deno.lock
+++ b/deno.lock
@@ -975,7 +975,7 @@
       "packages/resume": {
         "dependencies": [
           "npm:@deno/vite-plugin@1.0.4",
-          "npm:@types/node@22.13.10",
+          "npm:@types/node@22.14.1",
           "npm:effect@~3.13.10",
           "npm:vitest@3.1.1",
           "npm:yaml@2.7.1"
@@ -985,7 +985,7 @@
         "dependencies": [
           "npm:@deno/vite-plugin@1.0.4",
           "npm:@types/json-schema@7.0.15",
-          "npm:@types/node@22.13.10",
+          "npm:@types/node@22.14.1",
           "npm:effect@~3.13.10",
           "npm:vitest@3.1.1"
         ]

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741865919,
-        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {

--- a/packages/resume/deno.json
+++ b/packages/resume/deno.json
@@ -3,7 +3,7 @@
 	"version": "0.0.2",
 	"imports": {
 		"@deno/vite-plugin": "npm:@deno/vite-plugin@1.0.4",
-		"@types/node": "npm:@types/node@22.13.10",
+		"@types/node": "npm:@types/node@22.14.1",
 		"effect": "npm:effect@~3.13.10",
 	  "vitest": "npm:vitest@3.1.1",
 		"yaml": "npm:yaml@2.7.1"

--- a/packages/resume/deno.json
+++ b/packages/resume/deno.json
@@ -4,8 +4,8 @@
 	"imports": {
 		"@deno/vite-plugin": "npm:@deno/vite-plugin@1.0.4",
 		"@types/node": "npm:@types/node@22.14.1",
-		"effect": "npm:effect@~3.13.10",
-	  "vitest": "npm:vitest@3.1.1",
+		"effect": "npm:effect@^3.14.10",
+		"vitest": "npm:vitest@3.1.1",
 		"yaml": "npm:yaml@2.7.1"
 	},
 	"tasks": {

--- a/packages/resume/deno.json
+++ b/packages/resume/deno.json
@@ -5,7 +5,7 @@
 		"@deno/vite-plugin": "npm:@deno/vite-plugin@1.0.4",
 		"@types/node": "npm:@types/node@22.13.10",
 		"effect": "npm:effect@~3.13.10",
-		"vitest": "npm:vitest@3.0.8",
+	  "vitest": "npm:vitest@3.1.1",
 		"yaml": "npm:yaml@2.7.0"
 	},
 	"tasks": {

--- a/packages/resume/deno.json
+++ b/packages/resume/deno.json
@@ -35,7 +35,7 @@
 		},
 		"test": {
 			"description": "Run tests",
-			"command": "deno run -A --inspect npm:vitest@3.0.8 --inspect --no-file-parallelism"
+			"command": "deno run -A --inspect npm:vitest@3.1.1 --inspect --no-file-parallelism"
 		}
 	}
 }

--- a/packages/resume/deno.json
+++ b/packages/resume/deno.json
@@ -6,7 +6,7 @@
 		"@types/node": "npm:@types/node@22.13.10",
 		"effect": "npm:effect@~3.13.10",
 	  "vitest": "npm:vitest@3.1.1",
-		"yaml": "npm:yaml@2.7.0"
+		"yaml": "npm:yaml@2.7.1"
 	},
 	"tasks": {
 		"format": {

--- a/packages/schema-resume/deno.json
+++ b/packages/schema-resume/deno.json
@@ -12,7 +12,7 @@
 		"@deno/vite-plugin": "npm:@deno/vite-plugin@1.0.4",
 		"@types/json-schema": "npm:@types/json-schema@7.0.15",
 		"@types/node": "npm:@types/node@22.14.1",
-		"effect": "npm:effect@~3.13.10",
+		"effect": "npm:effect@^3.14.10",
 		"vitest": "npm:vitest@3.1.1"
 	},
 	"tasks": {

--- a/packages/schema-resume/deno.json
+++ b/packages/schema-resume/deno.json
@@ -13,7 +13,7 @@
 		"@types/json-schema": "npm:@types/json-schema@7.0.15",
 		"@types/node": "npm:@types/node@22.13.10",
 		"effect": "npm:effect@~3.13.10",
-		"vitest": "npm:vitest@3.0.8"
+		"vitest": "npm:vitest@3.1.1"
 	},
 	"tasks": {
 		"format": {

--- a/packages/schema-resume/deno.json
+++ b/packages/schema-resume/deno.json
@@ -37,7 +37,7 @@
 			"description": "Lint all files and write changes"
 		},
 		"test": {
-			"command": "deno run -A --inspect npm:vitest@3.0.8",
+			"command": "deno run -A --inspect npm:vitest@3.1.1",
 			"description": "Run tests"
 		},
 		"typecheck": {

--- a/packages/schema-resume/deno.json
+++ b/packages/schema-resume/deno.json
@@ -11,7 +11,7 @@
 	"imports": {
 		"@deno/vite-plugin": "npm:@deno/vite-plugin@1.0.4",
 		"@types/json-schema": "npm:@types/json-schema@7.0.15",
-		"@types/node": "npm:@types/node@22.13.10",
+		"@types/node": "npm:@types/node@22.14.1",
 		"effect": "npm:effect@~3.13.10",
 		"vitest": "npm:vitest@3.1.1"
 	},

--- a/packages/schema-resume/src/schema-primitive/iso8601-date-string/iso8601-date-string.spec.ts
+++ b/packages/schema-resume/src/schema-primitive/iso8601-date-string/iso8601-date-string.spec.ts
@@ -234,6 +234,9 @@ describe('ISO8601Date', () => {
 			).toMatchInlineSnapshot(`
 				"{
 					"$schema": "http://json-schema.org/draft-07/schema#",
+					"title": "ISO 8601 Date string",
+					"description": "A date string conforming to the ISO 8601 format. valid inputs will be converter to fully qualified ISO 8601 strings.",
+					"format": "date-time",
 					"type": "string"
 				}"
 			`)
@@ -243,6 +246,9 @@ describe('ISO8601Date', () => {
 			).toMatchInlineSnapshot(`
 				"{
 					"$schema": "http://json-schema.org/draft-07/schema#",
+					"title": "ISO 8601 Date string",
+					"description": "A date string conforming to the ISO 8601 format. valid inputs will be converter to fully qualified ISO 8601 strings.",
+					"format": "date-time",
 					"type": "string"
 				}"
 			`)


### PR DESCRIPTION
This pull request includes updates to dependencies and configuration files, as well as enhancements to schema documentation. The changes ensure the use of the latest versions of dependencies, improve testing commands, and add descriptive metadata to the ISO 8601 date schema.

### Dependency Updates:
* Updated `vitest` to version `3.1.1`, `@types/node` to `22.14.1`, and `effect` to `^3.14.10` across multiple `deno.json` files to ensure compatibility with the latest features and fixes. (`[[1]](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL35-R43)`, `[[2]](diffhunk://#diff-68285fbdc064485a9ee7acb4919b7bf6b79a928825fa2554198415ffd60901e8L6-R9)`, `[[3]](diffhunk://#diff-93010554af580a51e0400e18e885ef3149a109636c486d56ebf2eac14ff61567L14-R16)`)
* Updated `yaml` to version `2.7.1` in `packages/resume/deno.json` for improved YAML parsing. (`[packages/resume/deno.jsonL6-R9](diffhunk://#diff-68285fbdc064485a9ee7acb4919b7bf6b79a928825fa2554198415ffd60901e8L6-R9)`)

### Configuration Changes:
* Removed the `useDenoValue` option from `.idea/deno.xml` to simplify the configuration. (`[.idea/deno.xmlL5](diffhunk://#diff-57d2ceb7d5cf985ba2188f185eadfdee11ad610c347975455a52052507ba1550L5)`)
* Updated test commands in `deno.json` files to use the latest `vitest` version (`3.1.1`) for consistent testing behavior. (`[[1]](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL35-R43)`, `[[2]](diffhunk://#diff-68285fbdc064485a9ee7acb4919b7bf6b79a928825fa2554198415ffd60901e8L38-R38)`, `[[3]](diffhunk://#diff-93010554af580a51e0400e18e885ef3149a109636c486d56ebf2eac14ff61567L40-R40)`)

### Schema Documentation Enhancements:
* Added `title`, `description`, and `format` metadata to the ISO 8601 date schema in `iso8601-date-string.spec.ts` for better schema clarity and validation. (`[[1]](diffhunk://#diff-259eb7a69a4bbe6e38d5bf0713e837daaefe9565b22ce65fe61952fc5fccd21cR237-R239)`, `[[2]](diffhunk://#diff-259eb7a69a4bbe6e38d5bf0713e837daaefe9565b22ce65fe61952fc5fccd21cR249-R251)`)